### PR TITLE
Add RefreshIcon to top menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { InformationCircleIcon } from '@heroicons/react/outline'
+import { InformationCircleIcon, RefreshIcon } from '@heroicons/react/outline'
 import { ChartBarIcon } from '@heroicons/react/outline'
 import { useState, useEffect } from 'react'
 import { Alert } from './components/alerts/Alert'
@@ -115,6 +115,10 @@ function App() {
     <div className="py-8 max-w-7xl mx-auto sm:px-6 lg:px-8">
       <div className="flex w-80 mx-auto items-center mb-8">
         <h1 className="text-xl grow font-bold">Not Wordle</h1>
+        <RefreshIcon
+          className="h-6 w-6 cursor-pointer"
+          onClick={() => window.location.reload()}
+        />
         <InformationCircleIcon
           className="h-6 w-6 cursor-pointer"
           onClick={() => setIsInfoModalOpen(true)}


### PR DESCRIPTION
When app is added to homescreen, sometimes when a new day is opened it is still loaded from memory and it cannot show the new word prompt.

Pull to refresh doesn't work, so force closing the 'app' is the only solution.

This adds a simple button that allows reloading of the page.