### PR TITLE
Fix the link to suggest to add a project

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Open [http://localhost:3000](http://localhost:3000) in browser.
 - [Stockle](https://stockle.win/): Guess the stock or ETF
 - [AI-powered](https://github.com/asirota/wordle-ai): Includes an AI component
 
-_Want to add one to the list? Just make a pull request or [let us know via a comment here](/issues/#120)_
+_Want to add one to the list? Just make a pull request or [let us know via a comment here](https://github.com/cwackerfuss/react-wordle/issues/120)_
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Open [http://localhost:3000](http://localhost:3000) in browser.
 - [Stockle](https://stockle.win/): Guess the stock or ETF
 - [AI-powered](https://github.com/asirota/wordle-ai): Includes an AI component
 
-_Want to add one to the list? Just make a pull request or [let us know via a comment here](#120)_
+_Want to add one to the list? Just make a pull request or [let us know via a comment here](/issues/#120)_
 
 ## FAQ
 


### PR DESCRIPTION
I didn't know how to use a relative path. But an absolute link is better than a broken link I think.