### PR TITLE
Moved hard mode to settings modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,7 @@
 import {
   InformationCircleIcon,
   ChartBarIcon,
-  SunIcon,
-  MoonIcon,
-  CakeIcon,
-  AcademicCapIcon,
+  CogIcon,
 } from '@heroicons/react/outline'
 import { useState, useEffect } from 'react'
 import { Alert } from './components/alerts/Alert'
@@ -13,6 +10,7 @@ import { Keyboard } from './components/keyboard/Keyboard'
 import { AboutModal } from './components/modals/AboutModal'
 import { InfoModal } from './components/modals/InfoModal'
 import { StatsModal } from './components/modals/StatsModal'
+import { SettingsModal } from './components/modals/SettingsModal'
 import {
   GAME_TITLE,
   WIN_MESSAGES,
@@ -54,6 +52,7 @@ function App() {
   const [isAboutModalOpen, setIsAboutModalOpen] = useState(false)
   const [isNotEnoughLetters, setIsNotEnoughLetters] = useState(false)
   const [isStatsModalOpen, setIsStatsModalOpen] = useState(false)
+  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false)
   const [isWordNotFoundAlertOpen, setIsWordNotFoundAlertOpen] = useState(false)
   const [isGameLost, setIsGameLost] = useState(false)
   const [isDarkMode, setIsDarkMode] = useState(
@@ -213,28 +212,6 @@ function App() {
         <h1 className="text-xl ml-2.5 grow font-bold dark:text-white">
           {GAME_TITLE}
         </h1>
-        {isHardMode ? (
-          <AcademicCapIcon
-            className="h-6 w-6 mr-2 cursor-pointer dark:stroke-white"
-            onClick={() => handleHardMode(!isHardMode)}
-          />
-        ) : (
-          <CakeIcon
-            className="h-6 w-6 mr-2 cursor-pointer dark:stroke-white"
-            onClick={() => handleHardMode(!isHardMode)}
-          />
-        )}
-        {isDarkMode ? (
-          <SunIcon
-            className="h-6 w-6 mr-2 cursor-pointer dark:stroke-white sun"
-            onClick={() => handleDarkMode(!isDarkMode)}
-          />
-        ) : (
-          <MoonIcon
-            className="h-6 w-6 mr-2 cursor-pointer theme-switcher moon"
-            onClick={() => handleDarkMode(!isDarkMode)}
-          />
-        )}
         <InformationCircleIcon
           className="h-6 w-6 mr-2 cursor-pointer dark:stroke-white"
           onClick={() => setIsInfoModalOpen(true)}
@@ -242,6 +219,10 @@ function App() {
         <ChartBarIcon
           className="h-6 w-6 mr-3 cursor-pointer dark:stroke-white"
           onClick={() => setIsStatsModalOpen(true)}
+        />
+        <CogIcon
+          className="h-6 w-6 mr-3 cursor-pointer dark:stroke-white"
+          onClick={() => setIsSettingsModalOpen(true)}
         />
       </div>
       <Grid
@@ -276,6 +257,14 @@ function App() {
       <AboutModal
         isOpen={isAboutModalOpen}
         handleClose={() => setIsAboutModalOpen(false)}
+      />
+      <SettingsModal
+        isOpen={isSettingsModalOpen}
+        handleClose={() => setIsSettingsModalOpen(false)}
+        isHardMode={isHardMode}
+        handleHardMode={handleHardMode}
+        isDarkMode={isDarkMode}
+        handleDarkMode={handleDarkMode}
       />
 
       <button

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -1,0 +1,37 @@
+import { BaseModal } from './BaseModal'
+import { SettingsToggle } from './SettingsToggle'
+
+type Props = {
+  isOpen: boolean
+  handleClose: () => void
+  isHardMode: boolean
+  handleHardMode: Function
+  isDarkMode: boolean
+  handleDarkMode: Function
+}
+
+export const SettingsModal = ({
+  isOpen,
+  handleClose,
+  isHardMode,
+  handleHardMode,
+  isDarkMode,
+  handleDarkMode,
+}: Props) => {
+  return (
+    <BaseModal title="Settings" isOpen={isOpen} handleClose={handleClose}>
+      <div className="grid-cols-2 gap-4">
+        <SettingsToggle
+          settingName="Hard Mode"
+          flag={isHardMode}
+          handleFlag={handleHardMode}
+        />
+        <SettingsToggle
+          settingName="Dark Mode"
+          flag={isDarkMode}
+          handleFlag={handleDarkMode}
+        />
+      </div>
+    </BaseModal>
+  )
+}

--- a/src/components/modals/SettingsToggle.tsx
+++ b/src/components/modals/SettingsToggle.tsx
@@ -1,0 +1,30 @@
+import classnames from 'classnames'
+
+type Props = {
+  settingName: string
+  flag: boolean
+  handleFlag: Function
+}
+
+export const SettingsToggle = ({ settingName, flag, handleFlag }: Props) => {
+  const toggleHolder = classnames(
+    'w-14 h-8 flex items-center bg-gray-300 rounded-full p-1 duration-300 ease-in-out cursor-pointer',
+    {
+      'bg-green-400': flag,
+    }
+  )
+  const toggleButton = classnames(
+    'bg-white w-6 h-6 rounded-full shadow-md transform duration-300 ease-in-out cursor-pointer',
+    {
+      'translate-x-6': flag,
+    }
+  )
+  return (
+    <div className="flex justify-between items-center gap-8 mt-2">
+      <h2 className="text-gray-500 dark:text-gray-300">{settingName}</h2>
+      <div className={toggleHolder} onClick={() => handleFlag(!flag)}>
+        <div className={toggleButton} />
+      </div>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -45,16 +45,6 @@ svg:hover {
   animation-duration: var(--animation-speed);
 }
 
-.sun:hover {
-  animation: rotate linear;
-  animation-duration: var(--animation-speed-fast);
-}
-
-.moon:hover {
-  animation: swivel linear;
-  animation-duration: var(--animation-speed);
-}
-
 @keyframes revealAbsentCharCell {
   0% {
     transform: rotateX(0deg);
@@ -120,27 +110,6 @@ svg:hover {
 
 .shadowed {
   text-shadow: 1px 1px 1px #000000;
-}
-
-@keyframes rotate {
-  0% {
-    transform: rotate(0);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-}
-
-@keyframes swivel {
-  0% {
-    transform: rotate(0deg);
-  }
-  50% {
-    transform: rotate(-45deg);
-  }
-  100% {
-    transition: rotate(0);
-  }
 }
 
 @keyframes float {


### PR DESCRIPTION
Removed unclear toggable hardmode icons. Moved hard mode setting to a settings modal popup. This setup closely aligns with the source material.

Fixes https://github.com/cwackerfuss/react-wordle/issues/37