### PR TITLE
Correctly set the animation colours for dark mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,14 @@
 @tailwind components;
 @tailwind utilities;
 
+html {
+  --default-cell-bg-color: theme('colors.slate.400');
+}
+
+.dark {
+  --default-cell-bg-color: theme('colors.slate.700');
+}
+
 .cell-fill-animation {
   animation: onTypeCell linear;
   animation-duration: 0.35s;
@@ -33,21 +41,21 @@
 @keyframes revealAbsentCharCell {
   0% {
     transform: rotateX(0deg);
-    background-color: theme('colors.slate.400');
-    border-color: theme('colors.slate.400');
+    background-color: var(--default-cell-bg-color);
+    border-color: var(--default-cell-bg-color);
   }
   100% {
     transform: rotateX(180deg);
-    background-color: theme('colors.slate.400');
-    border-color: theme('colors.slate.400');
+    background-color: var(--default-cell-bg-color);
+    border-color: var(--default-cell-bg-color);
   }
 }
 
 @keyframes revealCorrectCharCell {
   0% {
     transform: rotateX(0deg);
-    background-color: theme('colors.slate.400');
-    border-color: theme('colors.slate.400');
+    background-color: var(--default-cell-bg-color);
+    border-color: var(--default-cell-bg-color);
   }
   100% {
     transform: rotateX(180deg);
@@ -59,8 +67,8 @@
 @keyframes revealPresentCharCell {
   0% {
     transform: rotateX(0deg);
-    background-color: theme('colors.slate.400');
-    border-color: theme('colors.slate.400');
+    background-color: var(--default-cell-bg-color);
+    border-color: var(--default-cell-bg-color);
   }
   100% {
     transform: rotateX(180deg);


### PR DESCRIPTION
In dark mode the cell background colour is not `colors.slate.400` but `colors.slate.700`.
The revealing animation has to be aware of this.

### Before
![before](https://user-images.githubusercontent.com/8069999/153514897-9db6e772-961d-4339-96de-cc182822f352.gif)

### After
![after](https://user-images.githubusercontent.com/8069999/153514894-de3b9a04-1843-4829-93bb-fa6bf6b500e6.gif)

