### PR TITLE
Add configurable Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,7 @@ _Want to add one to the list? Just make a pull request or [let us know via a com
 - If the language has letters that are not present in English update the keyboard in [src/components/keyboard/Keyboard.tsx](src/components/keyboard/Keyboard.tsx)
 - If the language's letters are made of multiple unicode characters, use a grapheme splitter at various points throughout the app or normalize the input so that all of the letters are made of a single character
 - If the language is written right-to-left, prepend `\u202E` (the unicode right-to-left override character) to the return statement of the inner function in `generateEmojiGrid` in [src/lib/share.ts](src/lib/share.ts)
+
+### How can I add usage tracking?
+
+- In [.env](.env), add `REACT_APP_GOOGLE_MEASUREMENT_ID=G-XXXXXXXXXX`

--- a/README.md
+++ b/README.md
@@ -97,4 +97,5 @@ _Want to add one to the list? Just make a pull request or [let us know via a com
 
 ### How can I add usage tracking?
 
+- Create a Google Analytics 4 property and obtain the measurement ID (of the format `G-XXXXXXXXXX`)
 - In [.env](.env), add `REACT_APP_GOOGLE_MEASUREMENT_ID=G-XXXXXXXXXX`

--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,18 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Game</title>
+
+    <% if (process.env.NODE_ENV === 'production' && process.env.REACT_APP_GOOGLE_MEASUREMENT_ID != null) { %>
+      <!-- Global site tag (gtag.js) - Google Analytics -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id=%REACT_APP_GOOGLE_MEASUREMENT_ID%"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', '%REACT_APP_GOOGLE_MEASUREMENT_ID%');
+      </script>
+    <% } %>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
If `REACT_APP_GOOGLE_MEASUREMENT_ID` is provided in `.env` AND the app is running in production, the relevant Google Analytics scripts are included in `index.html`.