### PR TITLE
Black squares when sharing in dark mode

### DIFF
--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -27,9 +27,9 @@ export const generateEmojiGrid = (guesses: string[]) => {
             case 'present':
               return '🟨'
             default:
-              if(localStorage.getItem('theme') === 'dark') {
-				        return '⬛'
-			        }
+              if (localStorage.getItem('theme') === 'dark') {
+                return '⬛'
+              }
               return '⬜'
           }
         })

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -27,6 +27,9 @@ export const generateEmojiGrid = (guesses: string[]) => {
             case 'present':
               return '🟨'
             default:
+              if(localStorage.getItem('theme') === 'dark') {
+				        return '⬛'
+			        }
               return '⬜'
           }
         })


### PR DESCRIPTION
Makes the squares copied to the clipboard when pressing the share button black when playing in dark mode.