### PR TITLE
Pinned docker images to stable optimize versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node AS node_modules
+FROM node:16.14.0-alpine3.14 AS node_modules
 WORKDIR /app
 COPY package-lock.json package.json ./
 RUN npm install
@@ -7,7 +7,7 @@ COPY . .
 FROM node_modules AS prod_builder
 RUN npm run build
 
-FROM nginx AS prod
+FROM nginx:1.20.2-alpine AS prod
 COPY --from=prod_builder /app/build /usr/share/nginx/html
 
 FROM node_modules AS dev


### PR DESCRIPTION
Pinned Node and Nginx images to the latest stable versions.
- Version pinning will ensure all builds will have the same environment with the same version of Node and Nginx. 
This eliminates the unexpected errors when the current application dependencies will become unsupported with future versions of  Node and Nginx.
- Alpine images are lightweight, secure, and fast.
  - The development image size has been reduced from `1.29GB` to `407MB`.
  - The production image size has been reduced from `143MB` to `24.7MB`.
  - The build takes lesser time due to the smaller size of base images.

Testing:
- Build and start docker containers for both dev and prod env.
- Verified that the application is running and is accessible on the browser.
- Executed `npm run test` for development image and verified all test cases are successful.