### PR TITLE
fix(reveal): Change color after reveal

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,11 +5,17 @@
 :root {
   --animation-speed: 1000ms;
   --animation-speed-fast: 500ms;
-  --default-cell-bg-color: theme('colors.slate.400');
+  --default-cell-bg-color: theme('colors.white');
+  --default-cell-border-color: theme('colors.black');
+  --default-cell-text-color: theme('colors.black');
+  --absent-cell-bg-color: theme('colors.slate.400');
 }
 
 .dark {
-  --default-cell-bg-color: theme('colors.slate.700');
+  --default-cell-bg-color: theme('colors.slate.900');
+  --default-cell-border-color: theme('colors.white');
+  --default-cell-text-color: theme('colors.white');
+  --absent-cell-bg-color: theme('colors.slate.700');
 }
 
 .cell-fill-animation {
@@ -49,12 +55,13 @@ svg:hover {
   0% {
     transform: rotateX(0deg);
     background-color: var(--default-cell-bg-color);
-    border-color: var(--default-cell-bg-color);
+    border-color: var(--default-cell-border-color);
+    color: var(--default-cell-text-color);
   }
   100% {
     transform: rotateX(180deg);
-    background-color: var(--default-cell-bg-color);
-    border-color: var(--default-cell-bg-color);
+    background-color: var(--absent-cell-bg-color);
+    border-color: var(--absent-cell-bg-color);
   }
 }
 
@@ -62,7 +69,8 @@ svg:hover {
   0% {
     transform: rotateX(0deg);
     background-color: var(--default-cell-bg-color);
-    border-color: var(--default-cell-bg-color);
+    border-color: var(--default-cell-border-color);
+    color: var(--default-cell-text-color);
   }
   100% {
     transform: rotateX(180deg);
@@ -75,7 +83,8 @@ svg:hover {
   0% {
     transform: rotateX(0deg);
     background-color: var(--default-cell-bg-color);
-    border-color: var(--default-cell-bg-color);
+    border-color: var(--default-cell-border-color);
+    color: var(--default-cell-text-color);
   }
   100% {
     transform: rotateX(180deg);


### PR DESCRIPTION
It can be quite disorientating for all the keys to turn grey as soon as enter is pressed, and then change color after the reveal animation. This makes them stay the original color and only change to the final colour after the animation.

<details>
<summary>GIF: Light mode</summary>

![Peek 2022-02-12 09-12](https://user-images.githubusercontent.com/2062388/153683106-a895cc61-1263-4850-94bc-d7b81503e521.gif)

</details>

<details>
<summary>GIF: Dark mode</summary>

![Peek 2022-02-12 09-11](https://user-images.githubusercontent.com/2062388/153683109-252693b4-b7f4-4dda-a06f-5605d96713a8.gif)

</details>
