### PR TITLE
Bugfix: Added the ability to disable hard mode in the middle of a game

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -118,7 +118,7 @@ function App() {
   }
 
   const handleHardMode = (isHard: boolean) => {
-    if (guesses.length === 0) {
+    if (guesses.length === 0 || localStorage.getItem('gameMode') === 'hard') {
       setIsHardMode(isHard)
       localStorage.setItem('gameMode', isHard ? 'hard' : 'normal')
     } else {


### PR DESCRIPTION
This is a bugfix for this hard mode validation. The original wordle allows disabling hard mode in the middle of the game but does not allow enabling it.