### PR TITLE
add plausible analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,16 @@ _Want to add one to the list? Just make a pull request or [let us know via a com
 
 ### How can I add usage tracking?
 
-This repository includes support for Google Analytics, but, by default, this is disabled. To enable Google Analytics:
+This repository includes support for Google Analytics or [Plausible Analytics](https://plausible.io), but, by default, this is disabled.
+
+To enable Google Analytics:
 
 - Create a Google Analytics 4 property and obtain the measurement ID (of the format `G-XXXXXXXXXX`)
 - In [.env](.env), add `REACT_APP_GOOGLE_MEASUREMENT_ID=G-XXXXXXXXXX`
 
 Keep in mind that your region might have legislation about obtaining a user's consent before enabling trackers. This is up to downstream repos to implement.
+
+To enable Plausible Analytics:
+
+- Create a new website with Plausible Analytics with a given domain, e.g. `example.app`
+- In [.env](.env), add `REACT_APP_PLAUSIBLE_DOMAIN=example.app`

--- a/public/index.html
+++ b/public/index.html
@@ -34,6 +34,10 @@
         gtag('config', '%REACT_APP_GOOGLE_MEASUREMENT_ID%');
       </script>
     <% } %>
+    <% if (process.env.NODE_ENV === 'production' && process.env.REACT_APP_PLAUSIBLE_DOMAIN != null) { %>
+      <!-- Plausible Analytics -->
+      <script defer data-domain="%REACT_APP_PLAUSIBLE_DOMAIN%" src="https://plausible.io/js/plausible.js"></script>
+    <% } %>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
this adds the possibility to use plausible analytics instead of google analytics. not sure if it can be helpful for others but I am using this here: https://github.com/par-le/react-wordle