### PR TITLE
Secure production docker container: Run nginx with non root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ $> npm run start
 #### Development
 
 ```bash
-$> docker build -t game:dev .
-$> docker run -d -p 3000:3000 game:dev
+$> docker build -t reactle:dev -f docker/Dockerfile .
+$> docker run -d -p 3000:3000 --name reactle-dev reactle:dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) in browser.
@@ -30,8 +30,8 @@ Open [http://localhost:3000](http://localhost:3000) in browser.
 #### Production
 
 ```bash
-$> docker build --target=prod -t game:prod .
-$> docker run -d -p 80:80 game:prod
+$> docker build --target=prod -t reactle:prod -f docker/Dockerfile .
+$> docker run -d -p 80:8080  --name reactle-prod reactle:prod
 ```
 
 Open [http://localhost](http://localhost) in browser.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,11 +7,18 @@ COPY . .
 FROM node_modules AS prod_builder
 RUN npm run build
 
+## Production image
 FROM nginx:1.20.2-alpine AS prod
+COPY docker/etc/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY docker/etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
 COPY --from=prod_builder /app/build /usr/share/nginx/html
-# Default HTTP port of Nginx.
-EXPOSE 80
+COPY docker/build_system.sh .
+RUN ./build_system.sh && rm ./build_system.sh
+# port use by Nginx within docker network.
+EXPOSE 8080
+USER reactle
 
+## Development image
 FROM node_modules AS dev
 EXPOSE 3000
 CMD npm run start

--- a/docker/build_system.sh
+++ b/docker/build_system.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# Strict shell settings.
+set -e pipefall;
+set -u pipefall;
+
+UID=1001
+GID=1001
+USER=reactle
+GROUP=reactle
+
+# Enable print for all executed commands
+trace_on() { set -x;}
+# Disable print for all executed commands
+trace_off() { set +x;}
+
+add_custom_user_group() {
+    addgroup -g $GID -S $GROUP
+    adduser -S -D -H \
+        -u $UID \
+        -G $GROUP \
+        -s /sbin/nologin \
+        -h /var/cache/nginx \
+        $USER
+}
+
+add_user_permission() {
+    chown -R $USER:$GROUP \
+        /usr/share/nginx \
+        /var/cache/nginx \
+        /var/log/nginx \
+        /etc/nginx
+}
+
+trace_on
+    add_custom_user_group
+    add_user_permission
+trace_off

--- a/docker/etc/nginx/conf.d/default.conf
+++ b/docker/etc/nginx/conf.d/default.conf
@@ -1,0 +1,19 @@
+server {
+    # Since non-root user cannot bind to port below 1024
+    # We will use the docker port 8080 instead of port 80.
+    listen       8080;
+    listen  [::]:8080;
+    server_name  localhost;
+
+    # Location of build files.
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    # Redirect server error pages to the static page /50x.html
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/docker/etc/nginx/nginx.conf
+++ b/docker/etc/nginx/nginx.conf
@@ -1,0 +1,36 @@
+# Don't use default nginx user.
+# Intead let the non-root user run the nginx.
+# user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+
+# The nginx.pid file will be created when the nginx process starts.
+# This file can be deleted and created at any number of times during production.
+# So, we will store it in /tmp where non-root user have permission to access it.
+pid        /tmp/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
Running a docker container in production with a root user is not a good idea, since the root user can access a broader range of kernel services.

Following are some examples from [Stackoverflow](https://stackoverflow.com/questions/19054029/security-of-docker-as-it-runs-as-root-user).
- Manipulate network Interfaces, Routing tables, Netfilter rules.
- Create raw sockets (and generally speaking, "exotic" sockets, exercising code that has received less scrutiny than good old TCP and UDP).
- Mount/unmount/remount filesystems.
- Change file ownership, permissions, extended attributes, overriding regular permissions (i.e. using slightly different code paths);
etc.

### Changes in PR:
- Modified the Nginx configs to allow non-root users to run Nginx.
- Added custom 'reactle' user that will run the container.
- Exposed port 8080 of docker container since the non-root user cannot bind port below 1024.
- Updated the command to build and run docker containers.
