### PR TITLE
Draft: Experiment to fix 100vh issues on mobile browsers. 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import './App.css'
 import { AlertContainer } from './components/alerts/AlertContainer'
 import { useAlert } from './context/AlertContext'
 import { Navbar } from './components/navbar/Navbar'
+import useWindowDimensions from './hooks/useWindowDimensions'
 
 function App() {
   const prefersDarkMode = window.matchMedia(
@@ -137,6 +138,17 @@ function App() {
   const clearCurrentRowClass = () => {
     setCurrentRowClass('')
   }
+
+  const { width } = useWindowDimensions()
+  // calculate actual view height (fixes chrome scroll bug re url bar)
+  useEffect(() => {
+    // If less than most tablets, set CSS var to window height.
+    let value = '100vh'
+    if (width <= 1024) {
+      value = `${window.innerHeight}px`
+    }
+    document.documentElement.style.setProperty('--real100vh', value)
+  }, [width])
 
   useEffect(() => {
     saveGameStateToLocalStorage({ guesses, solution })
@@ -241,13 +253,13 @@ function App() {
   }
 
   return (
-    <div className="h-screen flex flex-col">
+    <div className="h-dynamic flex flex-col">
       <Navbar
         setIsInfoModalOpen={setIsInfoModalOpen}
         setIsStatsModalOpen={setIsStatsModalOpen}
         setIsSettingsModalOpen={setIsSettingsModalOpen}
       />
-      <div className="pt-2 px-1 pb-8 md:max-w-7xl w-full mx-auto sm:px-6 lg:px-8 flex flex-col grow">
+      <div className="pt-8 px-1 pb-8 md:max-w-7xl w-full mx-auto sm:px-6 lg:px-8 flex flex-col grow">
         <div className="pb-6 grow">
           <Grid
             guesses={guesses}

--- a/src/hooks/useWindowDimensions.jsx
+++ b/src/hooks/useWindowDimensions.jsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react'
+
+function getWindowDimensions() {
+  const { innerWidth: width, innerHeight: height } = window
+  return {
+    width,
+    height,
+  }
+}
+
+export default function useWindowDimensions() {
+  const [windowDimensions, setWindowDimensions] = useState(
+    getWindowDimensions()
+  )
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowDimensions(getWindowDimensions())
+    }
+
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+
+  return windowDimensions
+}

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,7 @@
 @tailwind utilities;
 
 :root {
+  --real100vh: 100vh;
   --animation-speed: 1000ms;
   --animation-speed-fast: 250ms;
   --default-cell-bg-color: theme('colors.white');

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,11 @@ module.exports = {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
   darkMode: 'class',
   theme: {
-    extend: {},
+    extend: {
+      height: {
+        'dynamic': 'var(--real100vh)',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
Added a custom hook that grabs the window's dimensions. On load, we then calculate the inner height of the window if we think the user is on a device smaller than a tablet. Added a little additional padding between the top navbar and the grid so that messages do not overlay the grid too much.

Tailwind was extended with a custom height that reads from this css variable.

This worked in test and on the browser emulating mobile devices. If everyone could test on additional devices, that would be very helpful.

Solution found from here: https://stackoverflow.com/questions/58886797/how-to-access-the-real-100vh-on-ios-in-css

Fixes https://github.com/cwackerfuss/react-wordle/issues/285