### PR TITLE
Fixed showing background color on progress bar before game ends

### DIFF
--- a/src/components/modals/StatsModal.tsx
+++ b/src/components/modals/StatsModal.tsx
@@ -63,6 +63,7 @@ export const StatsModal = ({
       <Histogram
         gameStats={gameStats}
         numberOfGuessesMade={numberOfGuessesMade}
+        gameEnded={isGameWon || isGameLost}
       />
       {(isGameLost || isGameWon) && (
         <div className="mt-5 sm:mt-6 columns-2 dark:text-white">

--- a/src/components/modals/StatsModal.tsx
+++ b/src/components/modals/StatsModal.tsx
@@ -63,7 +63,7 @@ export const StatsModal = ({
       <Histogram
         gameStats={gameStats}
         numberOfGuessesMade={numberOfGuessesMade}
-        gameEnded={isGameWon || isGameLost}
+        isGameWon={isGameWon}
       />
       {(isGameLost || isGameWon) && (
         <div className="mt-5 sm:mt-6 columns-2 dark:text-white">

--- a/src/components/stats/Histogram.tsx
+++ b/src/components/stats/Histogram.tsx
@@ -4,13 +4,13 @@ import { Progress } from './Progress'
 type Props = {
   gameStats: GameStats
   numberOfGuessesMade: number
-  gameEnded: boolean
+  isGameWon: boolean
 }
 
 export const Histogram = ({
   gameStats,
   numberOfGuessesMade,
-  gameEnded,
+  isGameWon,
 }: Props) => {
   const winDistribution = gameStats.winDistribution
   const maxValue = Math.max(...winDistribution)
@@ -21,7 +21,7 @@ export const Histogram = ({
         <Progress
           key={i}
           index={i}
-          currentDayStatRow={numberOfGuessesMade === i + 1 && gameEnded}
+          currentDayStatRow={numberOfGuessesMade === i + 1 && isGameWon}
           size={90 * (value / maxValue)}
           label={String(value)}
         />

--- a/src/components/stats/Histogram.tsx
+++ b/src/components/stats/Histogram.tsx
@@ -4,9 +4,14 @@ import { Progress } from './Progress'
 type Props = {
   gameStats: GameStats
   numberOfGuessesMade: number
+  gameEnded: boolean
 }
 
-export const Histogram = ({ gameStats, numberOfGuessesMade }: Props) => {
+export const Histogram = ({
+  gameStats,
+  numberOfGuessesMade,
+  gameEnded,
+}: Props) => {
   const winDistribution = gameStats.winDistribution
   const maxValue = Math.max(...winDistribution)
 
@@ -16,7 +21,7 @@ export const Histogram = ({ gameStats, numberOfGuessesMade }: Props) => {
         <Progress
           key={i}
           index={i}
-          currentDayStatRow={numberOfGuessesMade === i + 1}
+          currentDayStatRow={numberOfGuessesMade === i + 1 && gameEnded}
           size={90 * (value / maxValue)}
           label={String(value)}
         />


### PR DESCRIPTION
This is a case I had missed when I initially made the PR for highlighting the stat progress bar for current day guesses. It should only be highlighted when the game has ended. So I attempted a fix here.