### PR TITLE
Add a workaround for unit test ReferenceError

### DIFF
--- a/src/lib/share.test.ts
+++ b/src/lib/share.test.ts
@@ -4,7 +4,17 @@ const mockSolutionGetter = jest.fn()
 jest.mock('./words', () => ({
   ...jest.requireActual('./words'),
   get solution() {
-    return mockSolutionGetter()
+    // TODO A try/catch block is needed here since `solution` may be referenced
+    // during module import, triggering this getter before being completely
+    // initialized. A refactor of `solution` might be a better approach.
+    try {
+      return mockSolutionGetter()
+    } catch (e) {
+      if (!(e instanceof ReferenceError)) {
+        throw e
+      }
+      return ''
+    }
   },
 }))
 


### PR DESCRIPTION
Addresses #302. This feels a little hacky to me, looking for input. Another option would be a larger refactor of how `solution` is used across the app, or maybe some jest mocking fu beyond my knowledge.