### PR TITLE
Refactor word/solution length to be variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,19 @@ _Want to add one to the list? Just make a pull request or [let us know via a com
 
 ### How can I change the length of a guess?
 
-- Update the `MAX_WORD_LENGTH` variable in [src/constants/settings.ts](src/constants/settings.ts) to the desired length.
+The default configuration is for solutions and guesses of length five, but it is flexible enough to handle other lengths, even variable lengths each day.
+
+To configure for a different constant length:
+
 - Update the `WORDS` array in [src/constants/wordlist.ts](src/constants/wordlist.ts) to only include words of the new length.
-- Update the `VALID_GUESSES` array in [src/constants/validGuesses.ts](src/constants/validGuesses.ts) arrays to only include words of the new length.
+- Update the `VALID_GUESSES` array in [src/constants/validGuesses.ts](src/constants/validGuesses.ts) to only include words of the new length.
+
+To configure for variable lengths:
+
+- Update the `WORDS` array in [src/constants/wordlist.ts](src/constants/wordlist.ts) to include words of any of the variable lengths desired.
+- Update the `VALID_GUESSES` array in [src/constants/validGuesses.ts](src/constants/validGuesses.ts) to include words of any of the variable lengths desired.
+
+Note that guesses are validated against both the length of the solution, and presence in VALID_GUESSES.
 
 ### How can I create a version in another language?
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,10 +13,8 @@ import {
   HARD_MODE_ALERT_MESSAGE,
 } from './constants/strings'
 import {
-  MAX_WORD_LENGTH,
   MAX_CHALLENGES,
   REVEAL_TIME_MS,
-  GAME_LOST_INFO_DELAY,
   WELCOME_INFO_MODAL_MS,
 } from './constants/settings'
 import {
@@ -146,7 +144,7 @@ function App() {
     if (isGameWon) {
       const winMessage =
         WIN_MESSAGES[Math.floor(Math.random() * WIN_MESSAGES.length)]
-      const delayMs = REVEAL_TIME_MS * MAX_WORD_LENGTH
+      const delayMs = REVEAL_TIME_MS * solution.length
 
       showSuccessAlert(winMessage, {
         delayMs,
@@ -157,13 +155,13 @@ function App() {
     if (isGameLost) {
       setTimeout(() => {
         setIsStatsModalOpen(true)
-      }, GAME_LOST_INFO_DELAY)
+      }, (solution.length + 1) * REVEAL_TIME_MS)
     }
   }, [isGameWon, isGameLost, showSuccessAlert])
 
   const onChar = (value: string) => {
     if (
-      unicodeLength(`${currentGuess}${value}`) <= MAX_WORD_LENGTH &&
+      unicodeLength(`${currentGuess}${value}`) <= solution.length &&
       guesses.length < MAX_CHALLENGES &&
       !isGameWon
     ) {
@@ -182,7 +180,7 @@ function App() {
       return
     }
 
-    if (!(unicodeLength(currentGuess) === MAX_WORD_LENGTH)) {
+    if (!(unicodeLength(currentGuess) === solution.length)) {
       setCurrentRowClass('jiggle')
       return showErrorAlert(NOT_ENOUGH_LETTERS_MESSAGE, {
         onClose: clearCurrentRowClass,
@@ -212,12 +210,12 @@ function App() {
     // chars have been revealed
     setTimeout(() => {
       setIsRevealing(false)
-    }, REVEAL_TIME_MS * MAX_WORD_LENGTH)
+    }, REVEAL_TIME_MS * solution.length)
 
     const winningWord = isWinningWord(currentGuess)
 
     if (
-      unicodeLength(currentGuess) === MAX_WORD_LENGTH &&
+      unicodeLength(currentGuess) === solution.length &&
       guesses.length < MAX_CHALLENGES &&
       !isGameWon
     ) {
@@ -234,7 +232,7 @@ function App() {
         setIsGameLost(true)
         showErrorAlert(CORRECT_WORD_MESSAGE(solution), {
           persist: true,
-          delayMs: REVEAL_TIME_MS * MAX_WORD_LENGTH + 1,
+          delayMs: REVEAL_TIME_MS * solution.length + 1,
         })
       }
     }

--- a/src/components/grid/CurrentRow.tsx
+++ b/src/components/grid/CurrentRow.tsx
@@ -1,6 +1,5 @@
-import { MAX_WORD_LENGTH } from '../../constants/settings'
 import { Cell } from './Cell'
-import { unicodeSplit } from '../../lib/words'
+import { solution, unicodeSplit } from '../../lib/words'
 
 type Props = {
   guess: string
@@ -9,7 +8,7 @@ type Props = {
 
 export const CurrentRow = ({ guess, className }: Props) => {
   const splitGuess = unicodeSplit(guess)
-  const emptyCells = Array.from(Array(MAX_WORD_LENGTH - splitGuess.length))
+  const emptyCells = Array.from(Array(solution.length - splitGuess.length))
   const classes = `flex justify-center mb-1 ${className}`
 
   return (

--- a/src/components/grid/EmptyRow.tsx
+++ b/src/components/grid/EmptyRow.tsx
@@ -1,8 +1,8 @@
-import { MAX_WORD_LENGTH } from '../../constants/settings'
+import { solution } from '../../lib/words'
 import { Cell } from './Cell'
 
 export const EmptyRow = () => {
-  const emptyCells = Array.from(Array(MAX_WORD_LENGTH))
+  const emptyCells = Array.from(Array(solution.length))
 
   return (
     <div className="flex justify-center mb-1">

--- a/src/components/keyboard/Key.tsx
+++ b/src/components/keyboard/Key.tsx
@@ -1,8 +1,9 @@
 import { ReactNode } from 'react'
 import classnames from 'classnames'
 import { CharStatus } from '../../lib/statuses'
-import { MAX_WORD_LENGTH, REVEAL_TIME_MS } from '../../constants/settings'
+import { REVEAL_TIME_MS } from '../../constants/settings'
 import { getStoredIsHighContrastMode } from '../../lib/localStorage'
+import { solution } from '../../lib/words'
 
 type Props = {
   children?: ReactNode
@@ -21,7 +22,7 @@ export const Key = ({
   onClick,
   isRevealing,
 }: Props) => {
-  const keyDelayMs = REVEAL_TIME_MS * MAX_WORD_LENGTH
+  const keyDelayMs = REVEAL_TIME_MS * solution.length
   const isHighContrast = getStoredIsHighContrastMode()
 
   const classes = classnames(

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -1,8 +1,4 @@
-import { solution } from '../lib/words'
-
-export const MAX_WORD_LENGTH = solution.length
 export const MAX_CHALLENGES = 6
 export const ALERT_TIME_MS = 2000
 export const REVEAL_TIME_MS = 350
-export const GAME_LOST_INFO_DELAY = (MAX_WORD_LENGTH + 1) * REVEAL_TIME_MS
 export const WELCOME_INFO_MODAL_MS = 350


### PR DESCRIPTION
Addresses #302 by refactoring MAX_WORD_LENGTH to be dynamic. Instead of including it in `constants` this refactor changes the app to use `solution.length` where needed.

Since the app now supports flexible, varied length solutions and guesses per day (#252), it seemed moving related variables out of `constants` to be a reasonable refactor.

There's an alternative workaround in #308. Only one is necessary.

