### PR TITLE
Add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.dockerignore
+.git*
+.husky/
+.prettierrc
+.vscode/
+CODE_OF_CONDUCT.md
+README.md
+build/
+docker/Dockerfile
+node_modules/


### PR DESCRIPTION
```
docker build --no-cache -t reactle:dev --target node_modules -f docker/Dockerfile .
```

Build time w/o .dockerignore: 272.6s
=> => transferring context: 251.42MB

Build time w/ .dockerignore: 160.2s
=> => transferring context: 2.72kB

Plus less chance of docker layer cache invalidation.