### PR TITLE
Fix unable to mock solution in shared tests

### DIFF
--- a/src/lib/share.test.ts
+++ b/src/lib/share.test.ts
@@ -1,5 +1,3 @@
-import { generateEmojiGrid } from './share'
-
 const mockSolutionGetter = jest.fn()
 jest.mock('./words', () => ({
   ...jest.requireActual('./words'),
@@ -9,26 +7,28 @@ jest.mock('./words', () => ({
 }))
 
 describe('generateEmojiGrid', () => {
-  test('generates grid for ascii', () => {
+  test('generates grid for ascii', async () => {
     const guesses = ['EDCBA', 'VWXYZ', 'ABCDE']
     const tiles = ['C', 'P', 'A'] // Correct, Present, Absemt
     mockSolutionGetter.mockReturnValue('ABCDE')
 
-    const grid = generateEmojiGrid(guesses, tiles)
+    const grid = (await import('./share')).generateEmojiGrid(guesses, tiles)
     const gridParts = grid.split('\n')
     expect(gridParts[0]).toBe('PPCPP')
     expect(gridParts[1]).toBe('AAAAA')
     expect(gridParts[2]).toBe('CCCCC')
   })
-  test('generates grid for ascii', () => {
+  test('generates grid for ascii. With emoji guesses', async () => {
     const guesses = ['5️⃣4️⃣3️⃣2️⃣1️⃣', '♠️♥️♦️♣️🔔', '1️⃣2️⃣3️⃣4️⃣5️⃣']
     const tiles = ['C', 'P', 'A'] // Correct, Present, Absemt
     mockSolutionGetter.mockReturnValue('1️⃣2️⃣3️⃣4️⃣5️⃣')
 
-    const grid = generateEmojiGrid(guesses, tiles)
+    const grid = (await import('./share')).generateEmojiGrid(guesses, tiles)
     const gridParts = grid.split('\n')
     expect(gridParts[0]).toBe('PPCPP')
     expect(gridParts[1]).toBe('AAAAA')
     expect(gridParts[2]).toBe('CCCCC')
   })
 })
+
+export {}


### PR DESCRIPTION
### Summary of changes
This PR tries to solve the problem of the solution not being mocked properly in the shared tests. 
This committed change will assure that './words' will be imported dynamically only when needed and after the mock return value has been resolved in order to be correctly applied to the getter that is defined. Once './words' is imported into the running module, `solution` will have value in mockSolutionGetter.mockReturnValue to resolve and let its getter act upon it.   

To allow typescript isolated modules feature keep working, an empty export at the very end was needed as well now that there are no static imports in the entire module.

I have also renamed the second test to adhere to the `eslint` rule of avoiding using the same name on different running tests

Fixes #302

### How to test this?

- `npm run test`
