### PR TITLE
Added Aria Label to the keys in the keyboard.

### DIFF
--- a/src/components/keyboard/Key.tsx
+++ b/src/components/keyboard/Key.tsx
@@ -54,7 +54,7 @@ export const Key = ({
   }
 
   return (
-    <button style={styles} className={classes} onClick={handleClick}>
+    <button style={styles} aria-label={`${value} ${status}`} className={classes} onClick={handleClick}>
       {children || value}
     </button>
   )


### PR DESCRIPTION
This gives users of screen readers a chance to know if the letters are in the word, if they are present, and if they are in the correct position. In the below screenshots without this feature it would just say the letter instead of status too to a screen reader.
<img width="941" alt="Screen Shot 2022-04-01 at 12 25 56 PM 1" src="https://user-images.githubusercontent.com/13560664/161312940-e12969ce-b4b4-45ca-95f2-bee1c91da02d.png">
<img width="833" alt="Screen Shot 2022-04-01 at 12 24 57 PM" src="https://user-images.githubusercontent.com/13560664/161312990-a934df95-bf5c-40bc-bd4b-7161c4259ed4.png">
<img width="927" alt="Screen Shot 2022-04-01 at 12 24 28 PM" src="https://user-images.githubusercontent.com/13560664/161313002-d481c870-3a80-4b90-bd86-a6d68c5883d3.png">
<img width="918" alt="Screen Shot 2022-04-01 at 12 25 27 PM" src="https://user-images.githubusercontent.com/13560664/161313063-1bd890d9-1cb0-4fb6-9996-fdf8efe69a06.png">

Accessibility Fix.