### PR TITLE
Uzbek (lotin) version of Reactle added ✅  -> So'zzana

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Open [http://localhost](http://localhost) in browser.
 - [Rudle](https://rudle.vercel.app): Russian
 - [Sindhal](https://hellosindh.com/sindhal): Sindhi
 - [Szózat](https://szozat.miklosdanka.com/): Hungarian
+- [So'zzana](https://sozzana.netlify.app/): O'zbek (Lotin)
 - [Tàu Tâi-gí (Taigi Wordle)](https://tau.taigi.info/): Taigi (Taiwanese)
 - [Tlembung](https://tlembung.vercel.app/): Japanese
 - [Tugma](https://tugma.vercel.app): Hiligaynon (spoken in the Philippines)


### PR DESCRIPTION
I made an uzbek version of worlde. I have added uzbek words and translated it. 
I fully aware that there is already - [Wordlar](http://wordlar.uz/): Uzbek version exists. But mine is in Latin letters which are different than Kiril letters. So the words would be different too. 
You can compare them. I will leave a link to mine here: - [So'zzana](https://sozzana.netlify.app/): O'zbek (Lotin).
