### PR TITLE
add Malay Jawi translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Open [http://localhost](http://localhost) in browser.
 - [Boludle](https://www.boludle.com/): Argentinian
 - [Gerdle](https://gerdle.vext.co.uk/): Cornish (Kernowek)
 - [Jwordle](https://jwordle.vercel.app/): Japanese
+- [Katadel](https://katadel.vercel.app/): Jawi (Malay Arabic script)
 - [Keclap](https://keclap.xyz/): Sundanese
 - [Kelmaly](https://kelmaly.com/): Arabic
 - [Kerdle](https://kerdle.vercel.app/): Cornish/Kernewek (Standard Written Form)


### PR DESCRIPTION
Adding کاتادل (lit. Katadel), a Malay translation using the [Jawi alphabet](https://en.wikipedia.org/wiki/Jawi_alphabet). The only Arabic script wordle with text reshaping that I know of ;) Thank you very much btw for making it so easy to localize!