### PR TITLE
Adjust page size for mobile displays

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="h-full">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
@@ -39,9 +39,9 @@
       <script defer data-domain="%REACT_APP_PLAUSIBLE_DOMAIN%" src="https://plausible.io/js/plausible.js"></script>
     <% } %>
   </head>
-  <body>
+  <body class="h-full">
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
+    <div id="root" class="h-full"></div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -271,7 +271,7 @@ function App() {
   }
 
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex h-full flex-col">
       <Navbar
         setIsInfoModalOpen={setIsInfoModalOpen}
         setIsStatsModalOpen={setIsStatsModalOpen}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -288,16 +288,17 @@ function App() {
         </div>
       )}
 
-      <div className="mx-auto flex w-full grow flex-col px-1 pt-2 pb-8 sm:px-6 md:max-w-7xl lg:px-8">
-        <div className="grow pb-6">
-          <Grid
-            solution={solution}
-            guesses={guesses}
-            currentGuess={currentGuess}
-            isRevealing={isRevealing}
-            currentRowClassName={currentRowClass}
-          />
-        </div>
+      <div
+        className="absolute mx-auto flex w-full grow flex-col self-center px-1 pt-2 pb-8 sm:px-6 md:max-w-7xl lg:px-8"
+        id="game-container"
+      >
+        <Grid
+          solution={solution}
+          guesses={guesses}
+          currentGuess={currentGuess}
+          isRevealing={isRevealing}
+          currentRowClassName={currentRowClass}
+        />
         <Keyboard
           onChar={onChar}
           onDelete={onDelete}

--- a/src/components/grid/Cell.tsx
+++ b/src/components/grid/Cell.tsx
@@ -25,7 +25,7 @@ export const Cell = ({
   const isHighContrast = getStoredIsHighContrastMode()
 
   const classes = classnames(
-    'w-14 h-14 border-solid border-2 flex items-center justify-center mx-0.5 text-4xl font-bold rounded dark:text-white',
+    'w-full border-solid border-2 flex items-center justify-center mx-0.5 sm-y:text-base sm-y:leading-4 text-4xl font-bold rounded dark:text-white',
     {
       'bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-600':
         !status,

--- a/src/components/grid/Cell.tsx
+++ b/src/components/grid/Cell.tsx
@@ -25,7 +25,7 @@ export const Cell = ({
   const isHighContrast = getStoredIsHighContrastMode()
 
   const classes = classnames(
-    'w-full border-solid border-2 flex items-center justify-center mx-0.5 sm-y:text-base sm-y:leading-4 text-4xl font-bold rounded dark:text-white',
+    'w-full h-full aspect-square -m-px border-solid border-2 flex items-center justify-center sm-y:text-base sm-y:leading-4 text-4xl font-bold rounded dark:text-white',
     {
       'bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-600':
         !status,

--- a/src/components/grid/CompletedRow.tsx
+++ b/src/components/grid/CompletedRow.tsx
@@ -11,10 +11,10 @@ type Props = {
 export const CompletedRow = ({ solution, guess, isRevealing }: Props) => {
   const statuses = getGuessStatuses(solution, guess)
   const splitGuess = unicodeSplit(guess)
-  const style = { gridTemplateColumns: `repeat(${solution.length}, 1fr)` }
+  const gridTemplateColumns = `repeat(${solution.length}, 1fr)`
 
   return (
-    <div className="grid gap-1" style={style}>
+    <div className="grid gap-1" style={{ gridTemplateColumns }}>
       {splitGuess.map((letter, i) => (
         <Cell
           key={i}

--- a/src/components/grid/CompletedRow.tsx
+++ b/src/components/grid/CompletedRow.tsx
@@ -11,9 +11,10 @@ type Props = {
 export const CompletedRow = ({ solution, guess, isRevealing }: Props) => {
   const statuses = getGuessStatuses(solution, guess)
   const splitGuess = unicodeSplit(guess)
+  const style = { gridTemplateColumns: `repeat(${solution.length}, 1fr)` }
 
   return (
-    <div className="mb-1 flex justify-center">
+    <div className="grid gap-1" style={style}>
       {splitGuess.map((letter, i) => (
         <Cell
           key={i}

--- a/src/components/grid/CurrentRow.tsx
+++ b/src/components/grid/CurrentRow.tsx
@@ -10,10 +10,10 @@ export const CurrentRow = ({ guess, className }: Props) => {
   const splitGuess = unicodeSplit(guess)
   const emptyCells = Array.from(Array(solution.length - splitGuess.length))
   const classes = `grid gap-1 ${className}`
-  const style = { gridTemplateColumns: `repeat(${solution.length}, 1fr)` }
+  const gridTemplateColumns = `repeat(${solution.length}, 1fr)`
 
   return (
-    <div className={classes} style={style}>
+    <div className={classes} style={{ gridTemplateColumns }}>
       {splitGuess.map((letter, i) => (
         <Cell key={i} value={letter} />
       ))}

--- a/src/components/grid/CurrentRow.tsx
+++ b/src/components/grid/CurrentRow.tsx
@@ -9,10 +9,11 @@ type Props = {
 export const CurrentRow = ({ guess, className }: Props) => {
   const splitGuess = unicodeSplit(guess)
   const emptyCells = Array.from(Array(solution.length - splitGuess.length))
-  const classes = `flex justify-center mb-1 ${className}`
+  const classes = `grid gap-1 ${className}`
+  const style = { gridTemplateColumns: `repeat(${solution.length}, 1fr)` }
 
   return (
-    <div className={classes}>
+    <div className={classes} style={style}>
       {splitGuess.map((letter, i) => (
         <Cell key={i} value={letter} />
       ))}

--- a/src/components/grid/EmptyRow.tsx
+++ b/src/components/grid/EmptyRow.tsx
@@ -3,9 +3,10 @@ import { Cell } from './Cell'
 
 export const EmptyRow = () => {
   const emptyCells = Array.from(Array(solution.length))
+  const style = { gridTemplateColumns: `repeat(${solution.length}, 1fr)` }
 
   return (
-    <div className="mb-1 flex justify-center">
+    <div className="grid gap-1" style={style}>
       {emptyCells.map((_, i) => (
         <Cell key={i} />
       ))}

--- a/src/components/grid/EmptyRow.tsx
+++ b/src/components/grid/EmptyRow.tsx
@@ -3,10 +3,10 @@ import { Cell } from './Cell'
 
 export const EmptyRow = () => {
   const emptyCells = Array.from(Array(solution.length))
-  const style = { gridTemplateColumns: `repeat(${solution.length}, 1fr)` }
+  const gridTemplateColumns = `repeat(${solution.length}, 1fr)`
 
   return (
-    <div className="grid gap-1" style={style}>
+    <div className="grid gap-1" style={{ gridTemplateColumns }}>
       {emptyCells.map((_, i) => (
         <Cell key={i} />
       ))}

--- a/src/components/grid/Grid.tsx
+++ b/src/components/grid/Grid.tsx
@@ -51,7 +51,8 @@ export class Grid extends Component<Props> {
       this.props.guesses.length < MAX_CHALLENGES - 1
         ? Array.from(Array(MAX_CHALLENGES - 1 - this.props.guesses.length))
         : []
-    const gridStyle = { gridTemplateRows: `repeat(${MAX_CHALLENGES}, 1fr)` }
+    const maxHeight = MAX_CELL_SIZE * MAX_CHALLENGES
+    const gridTemplateRows = `repeat(${MAX_CHALLENGES}, 1fr)`
 
     return (
       <div
@@ -62,7 +63,7 @@ export class Grid extends Component<Props> {
         <div
           id="grid"
           className="grid gap-1 p-1"
-          style={gridStyle}
+          style={{ maxHeight, gridTemplateRows }}
           ref={this.gridRef}
         >
           {this.props.guesses.map((guess, i) => (

--- a/src/components/grid/Grid.tsx
+++ b/src/components/grid/Grid.tsx
@@ -1,4 +1,6 @@
-import { MAX_CHALLENGES } from '../../constants/settings'
+import { Component, createRef } from 'react'
+
+import { MAX_CELL_SIZE, MAX_CHALLENGES } from '../../constants/settings'
 import { CompletedRow } from './CompletedRow'
 import { CurrentRow } from './CurrentRow'
 import { EmptyRow } from './EmptyRow'
@@ -11,34 +13,79 @@ type Props = {
   currentRowClassName: string
 }
 
-export const Grid = ({
-  solution,
-  guesses,
-  currentGuess,
-  isRevealing,
-  currentRowClassName,
-}: Props) => {
-  const empties =
-    guesses.length < MAX_CHALLENGES - 1
-      ? Array.from(Array(MAX_CHALLENGES - 1 - guesses.length))
-      : []
+export class Grid extends Component<Props> {
+  gridContainerRef = createRef<HTMLDivElement>()
+  gridRef = createRef<HTMLDivElement>()
+  gridHeight: number = MAX_CELL_SIZE * MAX_CHALLENGES
 
-  return (
-    <>
-      {guesses.map((guess, i) => (
-        <CompletedRow
-          key={i}
-          solution={solution}
-          guess={guess}
-          isRevealing={isRevealing && guesses.length - 1 === i}
-        />
-      ))}
-      {guesses.length < MAX_CHALLENGES && (
-        <CurrentRow guess={currentGuess} className={currentRowClassName} />
-      )}
-      {empties.map((_, i) => (
-        <EmptyRow key={i} />
-      ))}
-    </>
-  )
+  handleResize() {
+    if (this.gridContainerRef.current && this.gridRef.current) {
+      this.gridHeight = this.gridContainerRef.current.clientHeight
+      const newWidth = Math.min(
+        Math.floor(this.gridHeight) *
+          (this.props.solution.length / MAX_CHALLENGES),
+        MAX_CELL_SIZE * this.props.solution.length
+      )
+      const newHeight =
+        MAX_CHALLENGES * Math.floor(newWidth / this.props.solution.length)
+      this.gridRef.current.style.width = `${newWidth}px`
+      this.gridRef.current.style.height = `${newHeight}px`
+    }
+  }
+
+  componentDidMount() {
+    this.handleResize()
+    window.addEventListener('resize', this.handleResize.bind(this))
+  }
+
+  componentDidUpdate() {
+    this.handleResize()
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize.bind(this))
+  }
+
+  render() {
+    const empties =
+      this.props.guesses.length < MAX_CHALLENGES - 1
+        ? Array.from(Array(MAX_CHALLENGES - 1 - this.props.guesses.length))
+        : []
+    const gridStyle = { gridTemplateRows: `repeat(${MAX_CHALLENGES}, 1fr)` }
+
+    return (
+      <div
+        className="flex grow justify-center overflow-hidden pb-6"
+        id="gridContainer"
+        ref={this.gridContainerRef}
+      >
+        <div
+          id="grid"
+          className="grid gap-1 p-1"
+          style={gridStyle}
+          ref={this.gridRef}
+        >
+          {this.props.guesses.map((guess, i) => (
+            <CompletedRow
+              key={i}
+              solution={this.props.solution}
+              guess={guess}
+              isRevealing={
+                this.props.isRevealing && this.props.guesses.length - 1 === i
+              }
+            />
+          ))}
+          {this.props.guesses.length < MAX_CHALLENGES && (
+            <CurrentRow
+              guess={this.props.currentGuess}
+              className={this.props.currentRowClassName}
+            />
+          )}
+          {empties.map((_, i) => (
+            <EmptyRow key={i} />
+          ))}
+        </div>
+      </div>
+    )
+  }
 }

--- a/src/components/modals/InfoModal.tsx
+++ b/src/components/modals/InfoModal.tsx
@@ -14,7 +14,7 @@ export const InfoModal = ({ isOpen, handleClose }: Props) => {
         change to show how close your guess was to the word.
       </p>
 
-      <div className="mb-1 mt-4 flex justify-center">
+      <div className="mb-1 mt-4 grid grid-cols-5 gap-1">
         <Cell
           isRevealing={true}
           isCompleted={true}
@@ -30,7 +30,7 @@ export const InfoModal = ({ isOpen, handleClose }: Props) => {
         The letter W is in the word and in the correct spot.
       </p>
 
-      <div className="mb-1 mt-4 flex justify-center">
+      <div className="mb-1 mt-4 grid grid-cols-5 gap-1">
         <Cell value="P" />
         <Cell value="I" />
         <Cell
@@ -46,7 +46,7 @@ export const InfoModal = ({ isOpen, handleClose }: Props) => {
         The letter L is in the word but in the wrong spot.
       </p>
 
-      <div className="mb-1 mt-4 flex justify-center">
+      <div className="mb-1 mt-4 grid grid-cols-5 gap-1">
         <Cell value="V" />
         <Cell value="A" />
         <Cell value="G" />

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -11,3 +11,4 @@ export const BLOWFISH_KEY = 'xcQUAHsik#Thq&LG*8es2DsZ$3bw^e'
 export const BLOWFISH_IV = '#45XmF^w'
 export const ENABLE_ARCHIVED_GAMES = false
 export const DATE_LOCALE = enUS
+export const MAX_CELL_SIZE = 60

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,7 @@
   --absent-cell-bg-color: theme('colors.slate.400');
   --correct-cell-bg-color: theme('colors.green.400');
   --present-cell-bg-color: theme('colors.yellow.400');
+  --navbar-height: 3rem;
 }
 
 .dark {
@@ -66,15 +67,20 @@ svg.cursor-pointer:hover {
   animation-duration: var(--animation-speed-fast);
 }
 
-.navbar {
-  margin-bottom: 2%;
-}
-
 .navbar-content {
   display: flex;
-  height: 3rem;
+  height: var(--navbar-height);
   align-items: center;
   justify-content: space-between;
+}
+
+#game-container {
+  --navbar-margin: 2%;
+  --full-navbar-height: calc(var(--navbar-height) + var(--navbar-margin));
+  /* This margin separates the game grid from the top of the screen,
+     so it must include the navbar height along with any padding */
+  margin-top: var(--full-navbar-height);
+  height: calc(100% - var(--full-navbar-height));
 }
 
 .right-icons {

--- a/src/index.css
+++ b/src/index.css
@@ -75,7 +75,7 @@ svg.cursor-pointer:hover {
 }
 
 #game-container {
-  --navbar-margin: 2%;
+  --navbar-margin: 2vw;
   --full-navbar-height: calc(var(--navbar-height) + var(--navbar-margin));
   /* This margin separates the game grid from the top of the screen,
      so it must include the navbar height along with any padding */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,13 @@ module.exports = {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
   darkMode: 'class',
   theme: {
-    extend: {},
+    extend: {
+      screens: {
+        // Set a custom responsive breakpoint for shorter screens,
+        // so we can shrink the board text
+        'sm-y': { raw: '(max-height: 600px)' },
+      },
+    },
   },
   plugins: [require('@tailwindcss/forms')],
 }


### PR DESCRIPTION
Opening a new PR for this per discussion in #294.

Setting height to 100vh causes an excessive page height on some mobile browsers, e.g. iOS Safari. The original Wordle avoids this by using `height: 100%` instead; this PR applies that same styling to Reactle, which appears to resolve the page height issues.

[Chozordle](https://chozordle.vercel.app) is a demo example of this change.