### PR TITLE
Consolidate CSS and fix focus ring colours

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,0 @@
-html.dark {
-  background-color: rgb(15, 23, 42);
-}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,3 @@
-import './App.css'
-
 import { ClockIcon } from '@heroicons/react/outline'
 import { format } from 'date-fns'
 import { default as GraphemeSplitter } from 'grapheme-splitter'

--- a/src/components/grid/Cell.tsx
+++ b/src/components/grid/Cell.tsx
@@ -25,8 +25,7 @@ export const Cell = ({
   const classes = classnames(
     'xxshort:w-11 xxshort:h-11 short:text-2xl short:w-12 short:h-12 w-14 h-14 border-solid border-2 flex items-center justify-center mx-0.5 text-4xl font-bold rounded dark:text-white',
     {
-      'bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-600':
-        !status,
+      'cell-bg border-slate-200 dark:border-slate-600': !status,
       'border-black dark:border-slate-100': value && !status,
       'absent shadowed': status === 'absent',
       'correct shadowed': status === 'correct',

--- a/src/components/grid/Cell.tsx
+++ b/src/components/grid/Cell.tsx
@@ -1,7 +1,6 @@
 import classnames from 'classnames'
 
 import { REVEAL_TIME_MS } from '../../constants/settings'
-import { getStoredIsHighContrastMode } from '../../lib/localStorage'
 import { CharStatus } from '../../lib/statuses'
 
 type Props = {
@@ -22,7 +21,6 @@ export const Cell = ({
   const isFilled = value && !isCompleted
   const shouldReveal = isRevealing && isCompleted
   const animationDelay = `${position * REVEAL_TIME_MS}ms`
-  const isHighContrast = getStoredIsHighContrastMode()
 
   const classes = classnames(
     'xxshort:w-11 xxshort:h-11 short:text-2xl short:w-12 short:h-12 w-14 h-14 border-solid border-2 flex items-center justify-center mx-0.5 text-4xl font-bold rounded dark:text-white',
@@ -30,16 +28,9 @@ export const Cell = ({
       'bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-600':
         !status,
       'border-black dark:border-slate-100': value && !status,
-      'absent shadowed bg-slate-400 dark:bg-slate-700 text-white border-slate-400 dark:border-slate-700':
-        status === 'absent',
-      'correct shadowed bg-orange-500 text-white border-orange-500':
-        status === 'correct' && isHighContrast,
-      'present shadowed bg-cyan-500 text-white border-cyan-500':
-        status === 'present' && isHighContrast,
-      'correct shadowed bg-green-500 text-white border-green-500':
-        status === 'correct' && !isHighContrast,
-      'present shadowed bg-yellow-500 text-white border-yellow-500':
-        status === 'present' && !isHighContrast,
+      'absent shadowed': status === 'absent',
+      'correct shadowed': status === 'correct',
+      'present shadowed': status === 'present',
       'cell-fill-animation': isFilled,
       'cell-reveal': shouldReveal,
     }

--- a/src/components/keyboard/Key.tsx
+++ b/src/components/keyboard/Key.tsx
@@ -28,11 +28,10 @@ export const Key = ({
     'xxshort:h-8 xxshort:w-8 xxshort:text-xxs xshort:w-10 xshort:h-10 flex short:h-12 h-14 items-center justify-center rounded mx-0.5 text-xs font-bold cursor-pointer select-none dark:text-white',
     {
       'transition ease-in-out': isRevealing,
-      'bg-slate-200 dark:bg-slate-600 hover:bg-slate-300 active:bg-slate-400':
-        !status,
+      'default-key': !status,
       absent: status === 'absent',
-      correct: status === 'correct',
-      present: status === 'present',
+      'correct correct-key': status === 'correct',
+      'present present-key': status === 'present',
     }
   )
 

--- a/src/components/keyboard/Key.tsx
+++ b/src/components/keyboard/Key.tsx
@@ -2,7 +2,6 @@ import classnames from 'classnames'
 import { ReactNode } from 'react'
 
 import { REVEAL_TIME_MS } from '../../constants/settings'
-import { getStoredIsHighContrastMode } from '../../lib/localStorage'
 import { CharStatus } from '../../lib/statuses'
 import { solution } from '../../lib/words'
 
@@ -24,7 +23,6 @@ export const Key = ({
   isRevealing,
 }: Props) => {
   const keyDelayMs = REVEAL_TIME_MS * solution.length
-  const isHighContrast = getStoredIsHighContrastMode()
 
   const classes = classnames(
     'xxshort:h-8 xxshort:w-8 xxshort:text-xxs xshort:w-10 xshort:h-10 flex short:h-12 h-14 items-center justify-center rounded mx-0.5 text-xs font-bold cursor-pointer select-none dark:text-white',
@@ -32,15 +30,9 @@ export const Key = ({
       'transition ease-in-out': isRevealing,
       'bg-slate-200 dark:bg-slate-600 hover:bg-slate-300 active:bg-slate-400':
         !status,
-      'bg-slate-400 dark:bg-slate-800 text-white': status === 'absent',
-      'bg-orange-500 hover:bg-orange-600 active:bg-orange-700 text-white':
-        status === 'correct' && isHighContrast,
-      'bg-cyan-500 hover:bg-cyan-600 active:bg-cyan-700 text-white':
-        status === 'present' && isHighContrast,
-      'bg-green-500 hover:bg-green-600 active:bg-green-700 text-white':
-        status === 'correct' && !isHighContrast,
-      'bg-yellow-500 hover:bg-yellow-600 active:bg-yellow-700 text-white':
-        status === 'present' && !isHighContrast,
+      absent: status === 'absent',
+      correct: status === 'correct',
+      present: status === 'present',
     }
   )
 

--- a/src/components/modals/BaseModal.tsx
+++ b/src/components/modals/BaseModal.tsx
@@ -38,7 +38,7 @@ export const BaseModal = ({ title, children, isOpen, handleClose }: Props) => {
             leaveFrom="opacity-100 translate-y-0 sm:scale-100"
             leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
           >
-            <div className="inline-block transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left align-bottom shadow-xl transition-all dark:bg-gray-800 sm:my-8 sm:w-full sm:max-w-sm sm:p-6 sm:align-middle">
+            <div className="modal-bg inline-block transform overflow-hidden rounded-lg px-4 pt-5 pb-4 text-left align-bottom shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 sm:align-middle">
               <button
                 onClick={() => handleClose()}
                 tabIndex={0}

--- a/src/components/modals/DatePickerModal.tsx
+++ b/src/components/modals/DatePickerModal.tsx
@@ -124,15 +124,15 @@ export const DatePickerModal = ({
         <button
           type="button"
           disabled={!isValidGameDate(getToday())}
-          className="mt-2 inline-flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-center text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:border-gray-200 disabled:bg-gray-500 disabled:bg-white disabled:text-gray-900
-          disabled:focus:outline-none disabled:dark:border-gray-600 disabled:dark:bg-gray-800 disabled:dark:text-gray-400 sm:text-base sm:text-base"
+          className="accent-button disabled:border-gray-200 disabled:bg-gray-500 disabled:bg-white disabled:text-gray-900
+          disabled:focus:outline-none disabled:dark:border-gray-600 disabled:dark:bg-gray-800 disabled:dark:text-gray-400"
           onClick={() => handleSelectDate(getToday())}
         >
           {DATEPICKER_CHOOSE_TEXT} {DATEPICKER_TODAY_TEXT}
         </button>
         <button
           type="button"
-          className="mt-2 inline-flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-center text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 "
+          className="accent-button"
           disabled={selectedDate >= getToday()}
           onClick={() => handleSelectDate(selectedDate)}
         >

--- a/src/components/modals/DatePickerModal.tsx
+++ b/src/components/modals/DatePickerModal.tsx
@@ -93,8 +93,8 @@ export const DatePickerModal = ({
                               prevMonthButtonDisabled &&
                               'cursor-not-allowed opacity-50'
                             }
-                            inline-flex rounded border border-gray-300 bg-white p-1 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-0
-                            dark:border-gray-600 dark:bg-slate-700 dark:text-gray-200 dark:focus:ring-blue-600
+                            inline-flex rounded border border-gray-300 bg-white p-1 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-0
+                            dark:border-gray-600 dark:bg-slate-700 dark:text-gray-200 
                         `}
                 >
                   <ChevronLeftIcon className="h-5 w-5 text-gray-600 dark:text-gray-300" />
@@ -109,8 +109,8 @@ export const DatePickerModal = ({
                               nextMonthButtonDisabled &&
                               'cursor-not-allowed opacity-50'
                             }
-                            inline-flex rounded border border-gray-300 bg-white p-1 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-0
-                            dark:border-gray-600 dark:bg-slate-700 dark:text-gray-200 dark:focus:ring-blue-600
+                            inline-flex rounded border border-gray-300 bg-white p-1 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-0
+                            dark:border-gray-600 dark:bg-slate-700 dark:text-gray-200
                         `}
                 >
                   <ChevronRightIcon className="h-5 w-5 text-gray-600 dark:text-gray-300" />

--- a/src/components/modals/StatsModal.tsx
+++ b/src/components/modals/StatsModal.tsx
@@ -116,7 +116,7 @@ export const StatsModal = ({
           <div>
             <button
               type="button"
-              className="mt-2 inline-flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-center text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:text-base"
+              className="accent-button"
               onClick={() => {
                 shareStatus(
                   solution,

--- a/src/components/stats/EmigratePanel.tsx
+++ b/src/components/stats/EmigratePanel.tsx
@@ -45,8 +45,7 @@ export const EmigratePanel = () => {
         disabled={!isCopyButtonEnabled}
         onClick={copyEmigrationCodeToClipboard}
         type="button"
-        className="mt-2 inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-left text-base font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:border-gray-200
-          disabled:bg-white disabled:text-gray-900 disabled:focus:outline-none disabled:dark:border-gray-600 disabled:dark:bg-gray-800 disabled:dark:text-gray-400 sm:text-sm"
+        className="accent-button migrate-button"
       >
         {isCopyButtonEnabled && (
           <DuplicateIcon className="mr-2 h-6 w-6 cursor-pointer dark:stroke-white" />

--- a/src/components/stats/ImmigratePanel.tsx
+++ b/src/components/stats/ImmigratePanel.tsx
@@ -95,8 +95,7 @@ export const ImmigratePanel = () => {
         disabled={!isSaveButtonEnabled}
         onClick={handleSaveButton}
         type="button"
-        className="mt-2 inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-left text-base font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:border-gray-200 
-          disabled:bg-white disabled:text-gray-900 disabled:focus:outline-none disabled:dark:border-gray-600 disabled:dark:bg-gray-800 disabled:dark:text-gray-400 sm:text-sm"
+        className="accent-button migrate-button"
       >
         {isSaveButtonEnabled && (
           <SaveIcon className="mr-2 h-6 w-6 cursor-pointer dark:stroke-white" />

--- a/src/components/stats/MigrationIntro.tsx
+++ b/src/components/stats/MigrationIntro.tsx
@@ -15,7 +15,7 @@ export const MigrationIntro = ({ handleMigrateStatsButton }: Props) => {
       <div className="mt-3 text-xs">{MIGRATE_DESCRIPTION_TEXT}</div>
       <button
         type="button"
-        className="mt-2 inline-flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-center text-base font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:text-sm"
+        className="accent-button "
         onClick={handleMigrateStatsButton}
       >
         <LogoutIcon className="mr-2 h-6 w-6 cursor-pointer dark:stroke-white" />

--- a/src/index.css
+++ b/src/index.css
@@ -5,24 +5,26 @@
 :root {
   --animation-speed: 1000ms;
   --animation-speed-fast: 250ms;
+
   --default-cell-bg-color: theme('colors.white');
   --default-cell-border-color: theme('colors.black');
   --default-cell-text-color: theme('colors.black');
+
   --absent-cell-bg-color: theme('colors.slate.400');
-  --correct-cell-bg-color: theme('colors.green.400');
-  --present-cell-bg-color: theme('colors.yellow.400');
+  --correct-cell-bg-color: theme('colors.green.500');
+  --present-cell-bg-color: theme('colors.yellow.500');
 }
 
 .dark {
   --default-cell-bg-color: theme('colors.slate.900');
   --default-cell-border-color: theme('colors.white');
   --default-cell-text-color: theme('colors.white');
-  --absent-cell-bg-color: theme('colors.slate.700');
+  --absent-cell-bg-color: theme('colors.slate.800');
 }
 
 .high-contrast {
-  --correct-cell-bg-color: theme('colors.orange.400');
-  --present-cell-bg-color: theme('colors.cyan.400');
+  --correct-cell-bg-color: theme('colors.orange.500');
+  --present-cell-bg-color: theme('colors.cyan.500');
 }
 
 .cell-fill-animation {

--- a/src/index.css
+++ b/src/index.css
@@ -2,7 +2,22 @@
 @tailwind components;
 @tailwind utilities;
 
+html {
+  background-color: var(--theme-bg);
+}
+
+.theme-bg {
+  background-color: var(--theme-bg);
+}
+
+.modal-bg {
+  background-color: var(--theme-modal-bg);
+}
+
 :root {
+  --theme-bg: theme('colors.white');
+  --theme-modal-bg: theme('colors.white');
+
   --animation-speed: 1000ms;
   --animation-speed-fast: 250ms;
 
@@ -22,6 +37,9 @@
 }
 
 .dark {
+  --theme-bg: theme('colors.slate.900');
+  --theme-modal-bg: theme('colors.gray.800');
+
   --default-cell-bg-color: theme('colors.slate.900');
   --default-cell-border-color: theme('colors.white');
   --default-cell-text-color: theme('colors.white');
@@ -37,6 +55,10 @@
 
   --correct-cell-active-bg-color: theme('colors.orange.700');
   --present-cell-active-bg-color: theme('colors.cyan.700');
+}
+
+.cell-bg {
+  background-color: var(--default-cell-bg-color);
 }
 
 .absent {

--- a/src/index.css
+++ b/src/index.css
@@ -16,12 +16,11 @@ html {
 
 :root {
   --theme-bg: theme('colors.white');
-  --theme-modal-bg: theme('colors.white');
+  --theme-modal-bg: theme('colors.white'); /* Also in .accent-button:focus */
 
   /* Also in .accent-button:focus */
   --theme-accent-bg: theme('colors.indigo.600');
   --theme-accent-hover: theme('colors.indigo.700');
-  --theme-accent-focus: theme('colors.indigo.500');
 
   --animation-speed: 1000ms;
   --animation-speed-fast: 250ms;
@@ -80,7 +79,7 @@ html {
 }
 
 .accent-button:focus {
-  @apply focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2;
+  @apply ring-offset-white focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:ring-offset-slate-800;
 }
 
 .migrate-button {

--- a/src/index.css
+++ b/src/index.css
@@ -34,11 +34,15 @@ html {
   --correct-cell-bg-color: theme('colors.green.500');
   --present-cell-bg-color: theme('colors.yellow.500');
 
-  --correct-cell-hover-bg-color: theme('colors.green.600');
-  --present-cell-hover-bg-color: theme('colors.yellow.600');
+  --correct-key-hover-bg-color: theme('colors.green.600');
+  --present-key-hover-bg-color: theme('colors.yellow.600');
 
-  --correct-cell-active-bg-color: theme('colors.green.700');
-  --present-cell-active-bg-color: theme('colors.yellow.700');
+  --correct-key-active-bg-color: theme('colors.green.700');
+  --present-key-active-bg-color: theme('colors.yellow.700');
+
+  --default-key-bg-color: theme('colors.slate.200');
+  --default-key-hover-color: theme('colors.slate.300');
+  --default-key-active-color: theme('colors.slate.400');
 }
 
 .dark {
@@ -49,17 +53,21 @@ html {
   --default-cell-border-color: theme('colors.white');
   --default-cell-text-color: theme('colors.white');
   --absent-cell-bg-color: theme('colors.slate.800');
+
+  --default-key-bg-color: theme('colors.slate.600');
+  --default-key-hover-color: theme('colors.slate.600');
+  --default-key-active-color: theme('colors.slate.600');
 }
 
 .high-contrast {
   --correct-cell-bg-color: theme('colors.orange.500');
   --present-cell-bg-color: theme('colors.cyan.500');
 
-  --correct-cell-hover-bg-color: theme('colors.orange.600');
-  --present-cell-hover-bg-color: theme('colors.cyan.600');
+  --correct-key-hover-bg-color: theme('colors.orange.600');
+  --present-key-hover-bg-color: theme('colors.cyan.600');
 
-  --correct-cell-active-bg-color: theme('colors.orange.700');
-  --present-cell-active-bg-color: theme('colors.cyan.700');
+  --correct-key-active-bg-color: theme('colors.orange.700');
+  --present-key-active-bg-color: theme('colors.cyan.700');
 }
 
 .accent-button {
@@ -105,20 +113,32 @@ html {
   color: white;
 }
 
-.correct:hover {
-  background-color: var(--correct-cell-hover-bg-color);
+.correct-key:hover {
+  background-color: var(--correct-key-hover-bg-color);
 }
 
-.present:hover {
-  background-color: var(--present-cell-hover-bg-color);
+.present-key:hover {
+  background-color: var(--present-key-hover-bg-color);
 }
 
-.correct:active {
-  background-color: var(--correct-cell-active-bg-color);
+.correct-key:active {
+  background-color: var(--correct-key-active-bg-color);
 }
 
-.present:active {
-  background-color: var(--present-cell-active-bg-color);
+.present-key:active {
+  background-color: var(--present-key-active-bg-color);
+}
+
+.default-key {
+  background-color: var(--default-key-bg-color);
+}
+
+.default-key:hover {
+  background-color: var(--default-key-hover-color);
+}
+
+.default-key:active {
+  background-color: var(--default-key-active-color);
 }
 
 .cell-fill-animation {

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,12 @@
   --absent-cell-bg-color: theme('colors.slate.400');
   --correct-cell-bg-color: theme('colors.green.500');
   --present-cell-bg-color: theme('colors.yellow.500');
+
+  --correct-cell-hover-bg-color: theme('colors.green.600');
+  --present-cell-hover-bg-color: theme('colors.yellow.600');
+
+  --correct-cell-active-bg-color: theme('colors.green.700');
+  --present-cell-active-bg-color: theme('colors.yellow.700');
 }
 
 .dark {
@@ -25,6 +31,46 @@
 .high-contrast {
   --correct-cell-bg-color: theme('colors.orange.500');
   --present-cell-bg-color: theme('colors.cyan.500');
+
+  --correct-cell-hover-bg-color: theme('colors.orange.600');
+  --present-cell-hover-bg-color: theme('colors.cyan.600');
+
+  --correct-cell-active-bg-color: theme('colors.orange.700');
+  --present-cell-active-bg-color: theme('colors.cyan.700');
+}
+
+.absent {
+  background-color: var(--absent-cell-bg-color);
+  border-color: var(--absent-cell-bg-color);
+  color: white;
+}
+
+.correct {
+  background-color: var(--correct-cell-bg-color);
+  border-color: var(--correct-cell-bg-color);
+  color: white;
+}
+
+.present {
+  background-color: var(--present-cell-bg-color);
+  border-color: var(--present-cell-bg-color);
+  color: white;
+}
+
+.correct:hover {
+  background-color: var(--correct-cell-hover-bg-color);
+}
+
+.present:hover {
+  background-color: var(--present-cell-hover-bg-color);
+}
+
+.correct:active {
+  background-color: var(--correct-cell-active-bg-color);
+}
+
+.present:active {
+  background-color: var(--present-cell-active-bg-color);
 }
 
 .cell-fill-animation {

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,11 @@ html {
   --theme-bg: theme('colors.white');
   --theme-modal-bg: theme('colors.white');
 
+  /* Also in .accent-button:focus */
+  --theme-accent-bg: theme('colors.indigo.600');
+  --theme-accent-hover: theme('colors.indigo.700');
+  --theme-accent-focus: theme('colors.indigo.500');
+
   --animation-speed: 1000ms;
   --animation-speed-fast: 250ms;
 
@@ -55,6 +60,27 @@ html {
 
   --correct-cell-active-bg-color: theme('colors.orange.700');
   --present-cell-active-bg-color: theme('colors.cyan.700');
+}
+
+.accent-button {
+  background-color: var(--theme-accent-bg);
+  @apply mt-2 inline-flex w-full items-center justify-center rounded-md border border-transparent px-4 py-2 text-center text-base font-medium text-white shadow-sm;
+}
+
+.accent-button:hover {
+  background-color: var(--theme-accent-hover);
+}
+
+.accent-button:focus {
+  @apply focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2;
+}
+
+.migrate-button {
+  @apply w-min text-left;
+}
+
+.migrate-button:disabled {
+  @apply disabled:border-gray-200 disabled:bg-white disabled:text-gray-900 disabled:focus:outline-none disabled:dark:border-gray-600 disabled:dark:bg-gray-800 disabled:dark:text-gray-400;
 }
 
 .cell-bg {
@@ -343,21 +369,26 @@ svg.cursor-pointer:hover {
 }
 
 .react-datepicker__day--selecting-range-start {
-  @apply border-2 border-indigo-600 bg-white;
+  border-color: var(--theme-accent-bg);
+  @apply border-2 bg-white;
 }
 
 .react-datepicker__day--selecting-range-end {
-  @apply border-2 border-indigo-600 bg-white;
+  border-color: var(--theme-accent-bg);
+  @apply border-2 bg-white;
 }
 
 .react-datepicker__day--selected {
-  @apply bg-indigo-600 text-white dark:text-white;
+  background-color: var(--theme-accent-bg);
+  @apply text-white dark:text-white;
 }
 
 .react-datepicker__day--range-start {
-  @apply bg-indigo-600 text-white hover:bg-white hover:text-gray-700;
+  background-color: var(--theme-accent-bg);
+  @apply text-white hover:bg-white hover:text-gray-700;
 }
 
 .react-datepicker__day--range-end {
-  @apply bg-indigo-600 text-white hover:bg-white hover:text-gray-700;
+  background-color: var(--theme-accent-bg);
+  @apply text-white hover:bg-white hover:text-gray-700;
 }


### PR DESCRIPTION
This PR brings a lot of colour choices from various files into the index.css file for much easier custom theming. Rather than searching through multiple files for background, key and accent colours you can change all (most) of the colours from the :root{} in index.css.

It also fixes issues brought up in issue #740, namely Inconsistent focus ring colours. It keeps the modal background colour in dark mode slightly lighter because I thought it actually looked nicer that way.